### PR TITLE
Rutas absolutas reemplazadas por @

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,9 @@ import '@fontsource/roboto/400.css'
 import '@fontsource/roboto/500.css'
 import '@fontsource/roboto/700.css'
 import { RouterProvider } from 'react-router-dom'
-import { router } from './routes'
+import { router } from '@/routes'
 import CssBaseline from '@mui/material/CssBaseline'
-import {AuthProvider} from "./context/AuthContext.tsx";
+import { AuthProvider } from "@/context/AuthContext.tsx"
 
 function App() {
 

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Navigate } from 'react-router-dom'
-import {useAuth} from "../../context/AuthContext.tsx";
+import { useAuth } from "@/context/AuthContext.tsx";
 
 interface ProtectedRouteProps {
     children: React.ReactNode // Elementos hijos que se renderizarán si el usuario está autenticado

--- a/src/components/pages/login/Login.test.tsx
+++ b/src/components/pages/login/Login.test.tsx
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi} from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter, useNavigate } from 'react-router-dom';
-import '@testing-library/jest-dom'; 
+import '@testing-library/jest-dom';
 import Login from './Login';
-import { AuthProvider } from '../../../context/AuthContext';
+import { AuthProvider } from '@/context/AuthContext';
 
-//Mock de Navegación 
+//Mock de Navegación
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
@@ -26,7 +26,7 @@ describe('Login Page', () => {
     expect(screen.getByRole('heading', { name: /Login/i })).toBeInTheDocument()
 
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
-    
+
     const passwordInput = screen.getByTestId('password-input')
     expect(passwordInput).toBeInTheDocument()
 
@@ -60,29 +60,29 @@ describe('Login Page', () => {
 
     //simulo carga del input y envio el form
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: '123' } })
-    
+
     fireEvent.submit(screen.getByRole('button', { name: /login/i }))
     // verifica que se muestra el mensaje de error para el email
     await waitFor(() => {
       expect(screen.getByText('La contraseña debe tener al menos 6 caracteres')).toBeInTheDocument()
-    })  
+    })
 
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: '' } })
     fireEvent.submit(screen.getByRole('button', { name: /login/i }))
     await waitFor(() => {
       expect(screen.getByText('Debe ingresar una contraseña')).toBeInTheDocument()
-    })  
+    })
 
   })
 
   it('Visibilidad de contraseña', async () => {
     render(<AuthProvider><BrowserRouter><Login /></BrowserRouter></AuthProvider>)
-  
+
     const passwordInput = screen.getByLabelText('Password') as HTMLInputElement
     const visibilityButton = screen.getByRole('button', { name: /display the password/i })
 
     expect(passwordInput.type).toBe('password')
-    
+
     // Verifica si el ícono es el de mostrar contraseña
     expect(visibilityButton).toBeInTheDocument()
     expect(visibilityButton).toHaveAttribute('aria-label', 'display the password')
@@ -115,7 +115,7 @@ describe('Login Page', () => {
     fireEvent.submit(screen.getByRole('button', { name: /login/i }))
 
     // verifico que 'navigate' sea llamado después de enviar el formulario
-    await waitFor(() => {expect(mockNavigate).toHaveBeenCalledWith('/')}) 
+    await waitFor(() => {expect(mockNavigate).toHaveBeenCalledWith('/')})
 
   })
 })

--- a/src/components/pages/welcome/Welcome.test.tsx
+++ b/src/components/pages/welcome/Welcome.test.tsx
@@ -2,9 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { Welcome } from './Welcome';
 import { BrowserRouter, useNavigate } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
-import '@testing-library/jest-dom'; 
+import '@testing-library/jest-dom';
 
-//Mock de Navegación 
+//Mock de Navegación
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
@@ -17,10 +17,10 @@ vi.mock('react-router-dom', async () => {
 describe('Welcome Page', () =>{
   it('Renderización correcta del componente', async () => {
     render(<BrowserRouter><Welcome /></BrowserRouter>,)
-    
+
     //rendering del logo
     expect(screen.getByAltText(/University Logo/i)).toBeInTheDocument()
-    
+
     //renderings de los botones
     expect(screen.getByRole('button', { name: /Iniciá sesión/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Registrate/i })).toBeInTheDocument()

--- a/src/components/pages/welcome/Welcome.tsx
+++ b/src/components/pages/welcome/Welcome.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Container, Stack, Typography } from '@mui/material'
-import { TransparentContainer } from '../../ui/TransparentContainer'
+import { TransparentContainer } from '@/components/ui/TransparentContainer'
 import { useNavigate } from 'react-router-dom'
 
 export function Welcome() {

--- a/src/components/ui/TransparentContainer.tsx
+++ b/src/components/ui/TransparentContainer.tsx
@@ -1,5 +1,5 @@
-import Box from "@mui/material/Box";
-import { ReactNode } from "react";
+import Box from "@mui/material/Box"
+import { ReactNode } from "react"
 
 export function TransparentContainer( {children, padding}: {children: ReactNode, padding: string}) {
   return(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from '@/App.tsx'
 import { createTheme, responsiveFontSizes, ThemeProvider } from '@mui/material'
 
 let unsamTheme = createTheme({

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,11 +1,11 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom'
-import Login from './components/pages/login/Login'
-import Main from './components/pages/main/Main'
-import Map from './components/pages/main/map/Map'
-import Register from './components/pages/register/Register'
-import NotFound from './components/pages/notFound/NotFound'
-import { Welcome } from './components/pages/welcome/Welcome'
-import {ProtectedRoute} from "./components/common/ProtectedRoute.tsx";
+import Login from '@/components/pages/login/Login'
+import Main from '@/components/pages/main/Main'
+import Map from '@/components/pages/main/map/Map'
+import Register from '@/components/pages/register/Register'
+import NotFound from '@/components/pages/notFound/NotFound'
+import { Welcome } from '@/components/pages/welcome/Welcome'
+import { ProtectedRoute } from "@/components/common/ProtectedRoute.tsx";
 
 
 export const router = createBrowserRouter([

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "Bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "types": ["vitest/globals"]
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,14 +3,14 @@
 
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import path from "path"
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      src: '/src',
-      components: '/src/components',
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
Buenas, pude implementar esta mejora que teníamos pendiente. Era un poco más complicado usando Vite, pero lo pude hacer andar.

Los imports pasaron de tener este formato:
`import { TransparentContainer } from '../../ui/TransparentContainer'`
A este:
`import { TransparentContainer } from '@/components/ui/TransparentContainer'`