### PR TITLE
Fix/theme

### DIFF
--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -8,15 +8,15 @@ export default function Nav() {
   return (
     <AppBar position="fixed" color="primary" sx={{ top: 'auto', bottom: 0 }} enableColorOnDark>
       <Toolbar>
-        <IconButton /* onClick={() => navigate("/profile")} */ aria-label='Perfil'>
+        <IconButton /* onClick={() => navigate("/profile")} */ color="secondary" aria-label='Perfil'>
           <UserCircle size={32} alt='Usuario' />
         </IconButton>
         <Box sx={{ flexGrow: 1 }} />
-        <IconButton /* onClick={() => navigate("/")} */ aria-label='Inicio'>
+        <IconButton /* onClick={() => navigate("/")} */ color="secondary" aria-label='Inicio'>
           <MapTrifold size={32} alt='Mapa' />
         </IconButton>
         <Box sx={{ flexGrow: 1 }} />
-        <IconButton /* onClick={() => navigate("/search")} */ aria-label='Buscar'>
+        <IconButton /* onClick={() => navigate("/search")} */ color="secondary" aria-label='Buscar'>
           <MagnifyingGlass size={32} alt='Lupa' />
         </IconButton>
       </Toolbar>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,10 +15,11 @@ let unsamTheme = createTheme({
     light: {
       palette: {
         primary: {
-          main:'#7DA1C4' /*Pantone 645 como indica la UNSAM, si cambia es por #00DC8C (color de ECyT).*/
+          main:'#7DA1C4', /*Pantone 645 como indica la UNSAM, si cambia es por #00DC8C (color de ECyT).*/
+          contrastText: '#FFFFFF' /*Blanco para el texto en el color principal*/
         },
         secondary: {
-          main:'#DEECF3' /*Gris clarito complementario, puede cambiar*/
+          main:'#FFFFFF'
         },
         tonalOffset: 0.1
       }


### PR DESCRIPTION
Buenas, este pr está orientado a normalizar los colores en todas las vistas. Modifiqué el color del texto del color primario por blanco y agregué al blanco como color secundario.
Igualmente, como digo en el commit, esta segunda adición no es genial, pero mantiene el código cortito por ahora. El beneficio de tenerlo como color secundario es que lo podés pasar como prop a los íconos de phosphor en vez de agregar `sx`.
Si nos decidimos por un color secundario más útil, cambio la forma de definir el color de estos íconos.

![image](https://github.com/user-attachments/assets/c077ef38-4208-4e7c-a9d2-0d03ce5348ab)
![image](https://github.com/user-attachments/assets/d9f669aa-6e7f-4bb4-9d3f-22bfb521b818)
