### PR TITLE
Maquetado de pantalla de búsqueda.

### DIFF
--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -16,7 +16,7 @@ export default function Nav() {
           <MapTrifold size={32} alt='Mapa' />
         </IconButton>
         <Box sx={{ flexGrow: 1 }} />
-        <IconButton /* onClick={() => navigate("/search")} */ color="secondary" aria-label='Buscar'>
+        <IconButton onClick={() => navigate("/search")} color="secondary" aria-label='Buscar'>
           <MagnifyingGlass size={32} alt='Lupa' />
         </IconButton>
       </Toolbar>

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -25,11 +25,11 @@ export default function SeachBar({ onSearch }:SeachBarProps) {
         sx={{
           '& .MuiOutlinedInput-root': {borderRadius:'4px 0 0 4px',height: '56px',
           '&.Mui-focused fieldset': {borderColor: '#5f83b1'},
-          '& .MuiInputLabel-root': {top: '-8px'} // Ajuste de la etiqueta para que quede centrada verticalmente 
+          '& .MuiInputLabel-root': {top: '-8px'} // Ajuste de la etiqueta para que quede centrada verticalmente
         }}}
         aria-label='Ingresar búsqueda'
       />
-      <IconButton 
+      <IconButton
           sx={{ padding: 1,
             fontSize: 32,
             height: '56px',
@@ -38,8 +38,9 @@ export default function SeachBar({ onSearch }:SeachBarProps) {
             '&:hover': {backgroundColor: '#5f83b1'},
             display: 'flex',
             justifyContent: 'center',
-            alignItems: 'center', 
+            alignItems: 'center',
            }}
+           color='secondary'
           aria-label="Buscar"
           onClick={handleSearch}>
        <MagnifyingGlass size={32} alt='Lupa'/>

--- a/src/components/pages/main/search/Search.tsx
+++ b/src/components/pages/main/search/Search.tsx
@@ -1,0 +1,52 @@
+import ClassRoomCard from "@/components/common/ClassRoomCard"
+import SearchBar from "@/components/common/SearchBar"
+import { ClassData } from "@/data/mock/ClassData"
+import { Box, Divider, Typography } from "@mui/material"
+
+const search = () => {
+  console.log('Result')
+}
+
+export function Search() {
+  return (
+    <Box display='flex' flexDirection='column' height='100vh' overflow='hidden'>
+      <Box flexShrink='0' paddingTop='2rem'>
+        <Typography variant="h5" fontWeight="bold">Búsqueda</Typography>
+        <SearchBar onSearch={() => search()} />
+      </Box>
+      <Divider variant='middle' flexItem/>
+      <Box sx={{overflowY: 'auto'}} paddingBottom='4rem'>
+        <ClassRoomCard
+          className={ClassData.className}
+          commission={ClassData.commission}
+          classroom={ClassData.classroom}
+          building={ClassData.building}
+          teacher={ClassData.teacher}
+          careers={ClassData.careers}
+          schedules={ClassData.schedules}
+          viewType={ClassData.viewType}
+        />
+        <ClassRoomCard
+          className={ClassData.className}
+          commission={ClassData.commission}
+          classroom={ClassData.classroom}
+          building={ClassData.building}
+          teacher={ClassData.teacher}
+          careers={ClassData.careers}
+          schedules={ClassData.schedules}
+          viewType={ClassData.viewType}
+        />
+        <ClassRoomCard
+          className={ClassData.className}
+          commission={ClassData.commission}
+          classroom={ClassData.classroom}
+          building={ClassData.building}
+          teacher={ClassData.teacher}
+          careers={ClassData.careers}
+          schedules={ClassData.schedules}
+          viewType={ClassData.viewType}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/src/data/mock/ClassData.tsx
+++ b/src/data/mock/ClassData.tsx
@@ -1,0 +1,11 @@
+export const ClassData = {
+  className: "Conceptos de Arquitectura y Sistemas Operativos",
+  // classroomType : "Aula",
+  commission: "C-TI09",
+  classroom: "A9",
+  building: "Tornavias",
+  teacher: ["Cosme Fulanito","Mr. X"],
+  careers: ["Tecnicatura en Programación Informática", "Tecnicatura en Redes","Diagnóstico por Imágenes"],
+  schedules: "08:00 - 10:00",
+  viewType: "standard"
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -5,8 +5,9 @@ import Map from '@/components/pages/main/map/Map'
 import Register from '@/components/pages/register/Register'
 import NotFound from '@/components/pages/notFound/NotFound'
 import { Welcome } from '@/components/pages/welcome/Welcome'
-import { ProtectedRoute } from "@/components/common/ProtectedRoute.tsx";
+import { ProtectedRoute } from "@/components/common/ProtectedRoute.tsx"
 import Profile from '@/components/pages/profile/Profile'
+import { Search } from '@/components/pages/main/search/Search'
 
 
 export const router = createBrowserRouter([
@@ -21,7 +22,8 @@ export const router = createBrowserRouter([
             </ProtectedRoute>,
         children: [
             { path: '/', element: <Map /> },
-            { path: '/profile', element: <Profile /> }
+            { path: '/profile', element: <Profile /> },
+            { path: '/search', element: <Search />}
         ],
         errorElement: <NotFound />
     },


### PR DESCRIPTION
Publico el maquetado de la pantalla de búsqueda en versión mobile (las vistas de tablet y compu zafan por suerte)

Se divide en el encabezado fijo en el que están el título y la barra de búsqueda y un contenedor para las cards. Ahora que salió en esta vista, podría fijar el título en la vista de perfil, que ahora mismo forma parte del Stack de botones.
El scroll vertical funciona correctamente y solo se activa cuando la cantidad de cards lo requiere.

Me hace un poquito de ruido tener el ícono de la lupa tanto en el botón de acción como en el botón de navegación. Capaz puede ser confuso para un usuario. Qué opinan?

Lo incluí dentro de la carpeta main, pero me dí cuenta que profile no está por fuera de la carpeta main. Podríamos cambiarlo de ubicación.

![image](https://github.com/user-attachments/assets/daf1e0eb-f2a0-4248-bd5f-89c35b84571c)

![image](https://github.com/user-attachments/assets/72a1e9e9-6089-4268-bca7-62b25deaf1a7)

![image](https://github.com/user-attachments/assets/7cf007db-768d-4a2b-b851-15cebb65f939)
