### PR TITLE
Vista search responsive

### DIFF
--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -7,6 +7,7 @@ export default function Nav() {
   const navigate = useNavigate()
   const {isAuthenticated} = useAuth()
   const location = useLocation()
+
   // Función para detectar rutas parciales o múltiples coincidencias
   const isActive = (paths: string | string[]) => {
     if (typeof paths === "string") {
@@ -21,7 +22,7 @@ export default function Nav() {
     )
   }
   return (
-    <AppBar className="footer-nav-bar" position="sticky" color="primary" sx={{ top: 'auto', bottom: 0, height: '10vh', display:'flex', justifyContent:'center', alignItems:'center' }} enableColorOnDark>
+    <AppBar className="footer-nav-bar" position="fixed" color="primary" sx={{ top: 'auto', bottom: 0, height: '10vh', display:'flex', justifyContent:'center', alignItems:'center' }} enableColorOnDark>
       <Toolbar sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%', height: '100%'}}>
         <IconButton onClick={() => navigate("/")} color='secondary' className={isActive('/')?'active':''} aria-label='Buscar'>
           <HouseSimple size={32} alt='Inicio'/>

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -22,7 +22,7 @@ export default function Nav() {
     )
   }
   return (
-    <AppBar className="footer-nav-bar" position="fixed" color="primary" sx={{ top: 'auto', bottom: 0, height: '10vh', display:'flex', justifyContent:'center', alignItems:'center' }} enableColorOnDark>
+    <AppBar className="footer-nav-bar" position="sticky" color="primary" sx={{ top: 'auto', bottom: 0, height: '10vh', display:'flex', justifyContent:'center', alignItems:'center' }} enableColorOnDark>
       <Toolbar sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%', height: '100%'}}>
         <IconButton onClick={() => navigate("/")} color='secondary' className={isActive('/')?'active':''} aria-label='Buscar'>
           <HouseSimple size={32} alt='Inicio'/>

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -30,13 +30,29 @@ export function Search() {
 
 
   return (
-    <Box display='flex' flexDirection='column' height='100vh' overflow='hidden'>
-      <Box flexShrink='0' paddingTop='2rem'>
-        <Typography variant="h5" fontWeight="bold">Búsqueda</Typography>
+    <Box
+     display='flex'
+     flexDirection='column'
+     height='100vh'
+     >
+
+      <Box flexShrink='0' position='sticky' top='0' zIndex='10'>
         <SearchBar onSearch={() => search()} />
+        <Divider variant='middle' flexItem/>
       </Box>
-      <Divider variant='middle' flexItem/>
-      <Box sx={{overflowY: 'auto', display: 'flex', flexDirection:{xs:'column',sm:'row'}, flexWrap:{xs:'nowrap', sm:'wrap'}, gap: '1rem', justifyContent:'center'}} padding='2rem'>
+
+      <Box
+        display='flex'
+        flex='1'
+        overflow='auto'
+        flexDirection={{xs:'column', sm:'row'}}
+        flexWrap={{xs:'nowrap', sm:'wrap'}}
+        justifyContent={{xs:'flex-start', sm:'center'}}
+        pt='1rem'
+        mx='2rem'
+        pb='7rem'
+        gap={{xs:'1rem', lg:'1rem 2rem', xl:'1rem 3rem'}}
+      >
         {
           classes.map((c: IClass) => (
             <ClassRoomCard
@@ -53,8 +69,8 @@ export function Search() {
             />
           ))
         }
-
       </Box>
+
       {/* Modal con mapa y detalles */}
       {currentClass && (
         <ClassInfoModal

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -50,7 +50,7 @@ export function Search() {
       >
         <Grid2
           container
-          rowSpacing='1rem'
+          rowSpacing='2rem'
           columnSpacing='2rem'
           columns={{xs: 1, sm: 2, lg:3}}
         >

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -36,7 +36,7 @@ export function Search() {
         <SearchBar onSearch={() => search()} />
       </Box>
       <Divider variant='middle' flexItem/>
-      <Box sx={{overflowY: 'auto', display: 'flex', flexDirection:'column', gap: '1rem'}} padding='2rem'>
+      <Box sx={{overflowY: 'auto', display: 'flex', flexDirection:{xs:'column',sm:'row'}, flexWrap:{xs:'nowrap', sm:'wrap'}, gap: '1rem', justifyContent:'center'}} padding='2rem'>
         {
           classes.map((c: IClass) => (
             <ClassRoomCard

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -1,7 +1,7 @@
 import ClassRoomCard from "@/components/common/ClassRoomCard"
 import SearchBar from "@/components/common/SearchBar"
 import { classes, IClass } from "@/data/mock/ClassData"
-import { Box, Divider, Typography } from "@mui/material"
+import { Box, Divider, Grid2, Typography } from "@mui/material"
 import { useState } from "react"
 import TornaviasSubsuelo from "@/components/pages/map/components/TornaviasSubsuelo"
 import ClassInfoModal from "@/components/common/Modal"
@@ -43,32 +43,36 @@ export function Search() {
 
       <Box
         display='flex'
-        flex='1'
         overflow='auto'
-        flexDirection={{xs:'column', sm:'row'}}
-        flexWrap={{xs:'nowrap', sm:'wrap'}}
-        justifyContent={{xs:'flex-start', sm:'center'}}
+        justifyContent='center'
         pt='1rem'
-        mx='2rem'
-        pb='7rem'
-        gap={{xs:'1rem', lg:'1rem 2rem', xl:'1rem 3rem'}}
+        px='2rem'
       >
-        {
-          classes.map((c: IClass) => (
-            <ClassRoomCard
-              key={c.id}
-              name={c.name}
-              commission={c.commission}
-              classroom={c.classroom}
-              building={c.building}
-              teacher={c.teacher}
-              careers={c.careers}
-              schedules={c.schedules}
-              viewType={c.viewType}
-              onClick={() => handleOpen(c)}
-            />
-          ))
-        }
+        <Grid2
+          container
+          rowSpacing='1rem'
+          columnSpacing='2rem'
+          columns={{xs: 1, sm: 2, lg:3}}
+        >
+          {
+            classes.map((c: IClass) => (
+              <Grid2 size={1}>
+                <ClassRoomCard
+                  key={c.id}
+                  name={c.name}
+                  commission={c.commission}
+                  classroom={c.classroom}
+                  building={c.building}
+                  teacher={c.teacher}
+                  careers={c.careers}
+                  schedules={c.schedules}
+                  viewType={c.viewType}
+                  onClick={() => handleOpen(c)}
+                />
+              </Grid2>
+            ))
+          }
+        </Grid2>
       </Box>
 
       {/* Modal con mapa y detalles */}

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -30,52 +30,54 @@ export function Search() {
 
 
   return (
+    // Contenedor principal que organiza la disposición de los elementos
     <Box
-     display='flex'
-     flexDirection='column'
-     height='100vh'
-     >
+      display='flex'
+      flexDirection='column'
+      height='100vh'
+      justifyContent='center'
+    >
 
+      {/* Barra de búsqueda fija */}
       <Box flexShrink='0' position='sticky' top='0' zIndex='10'>
         <SearchBar onSearch={() => search()} />
-        <Divider variant='middle' flexItem/>
+        <Divider variant='middle' flexItem />
       </Box>
 
-      <Box
-        display='flex'
-        overflow='auto'
-        justifyContent='center'
-        pt='1rem'
+      {/* Grilla para organizar las tarjetas de las aulas de manera responsive */}
+      <Grid2
+        container
+        rowSpacing='2rem'
+        columnSpacing={{ xs: '2rem', sm: '1.5rem' }}
+        columns={{ xs: 1, sm: 2, lg: 3, xl: 4 }}
+        maxHeight='90vh'
         px='2rem'
+        pt='1rem'
+        pb='7rem'
+        sx={{ overflowY: 'auto' }}
       >
-        <Grid2
-          container
-          rowSpacing='2rem'
-          columnSpacing='2rem'
-          columns={{xs: 1, sm: 2, lg:3}}
-        >
-          {
-            classes.map((c: IClass) => (
-              <Grid2 size={1}>
-                <ClassRoomCard
-                  key={c.id}
-                  name={c.name}
-                  commission={c.commission}
-                  classroom={c.classroom}
-                  building={c.building}
-                  teacher={c.teacher}
-                  careers={c.careers}
-                  schedules={c.schedules}
-                  viewType={c.viewType}
-                  onClick={() => handleOpen(c)}
-                />
-              </Grid2>
-            ))
-          }
-        </Grid2>
-      </Box>
+        {
+          // Mapeo de las clases para renderizar cada tarjeta de aula
+          classes.map((c: IClass) => (
+            <Grid2 size={1}>
+              <ClassRoomCard
+                key={c.id}
+                name={c.name}
+                commission={c.commission}
+                classroom={c.classroom}
+                building={c.building}
+                teacher={c.teacher}
+                careers={c.careers}
+                schedules={c.schedules}
+                viewType={c.viewType}
+                onClick={() => handleOpen(c)}
+              />
+            </Grid2>
+          ))
+        }
+      </Grid2>
 
-      {/* Modal con mapa y detalles */}
+      {/* Modal que muestra detalles de la clase seleccionada y un mapa */}
       {currentClass && (
         <ClassInfoModal
           open={open}
@@ -84,10 +86,13 @@ export function Search() {
           classroomType="Aula"
         >
           <section className="class-info-container">
+            {/* Título del modal con información del edificio y nivel */}
             <Typography id="modal-modal-title" variant="h6" component="h2" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
               {currentClass.building} - {currentClass.buildingLevel}
             </Typography>
+            {/* Mapa interactivo del subsuelo */}
             <TornaviasSubsuelo selectedClassRoomId={selectedClass?.classRoomId} onClassRoomClick={() => setSelectedClass(currentClass)} />
+            {/* Tarjeta con detalles adicionales de la clase */}
             <ClassRoomCard
               name={currentClass.name}
               commission={currentClass.commission}

--- a/src/data/mock/ClassData.tsx
+++ b/src/data/mock/ClassData.tsx
@@ -34,6 +34,24 @@ export const algo3Class: IClass = {
   viewType: 'standard'
 }
 
+export const algo2Class: IClass = {
+  id:2,
+  name: "Algoritmos 2",
+  classroomType : "Lab. de Computación",
+  commission: "C-TI10",
+  classroom: "Laboratorio de Computación 1",
+  classRoomId: 9,
+  building: "Tornavías",
+  buildingLevel: 'Subsuelo',
+  teacher: ["Cosme Fulanito","Mr. T"],
+  careers: ["Tecnicatura en Programación Informática", "Tecnicatura en Redes","Ciencia de Datos","Tecnicatura en Programación Informática",],
+  schedules: "18:00 - 22:00",
+  weekDays: ["Martes","Jueves"],
+  startDate: "2024-03-01",
+  endDate: "2025-07-01",
+  viewType: 'standard'
+}
+
 export interface IClass{
   id: number
   name: string
@@ -52,4 +70,4 @@ export interface IClass{
   viewType: string//'standard' | 'modal'
 }
 
-export const classes = [casoClass, algo3Class]
+export const classes = [casoClass, algo3Class, algo2Class, casoClass, algo3Class, algo2Class]

--- a/src/data/mock/ClassData.tsx
+++ b/src/data/mock/ClassData.tsx
@@ -70,4 +70,4 @@ export interface IClass{
   viewType: string//'standard' | 'modal'
 }
 
-export const classes = [casoClass, algo3Class, algo2Class, casoClass, algo3Class, algo2Class]
+export const classes = [casoClass, algo3Class, algo2Class, casoClass, algo3Class, algo2Class, casoClass, algo3Class, algo2Class]

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
 
+  overflow: hidden;
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;


### PR DESCRIPTION
Buenas! Me rompí un poco la cabeza con esto pero puedo publicar un pr más o menos decente.
Cambié bastante el estilo de la página search (menos lo respectivo al modal, eso no lo toque)
También implicó tocar el estilo de :root para perder ese scroll fuera de rango hacia arriba y hacia abajo que hace que la página "rebote"

Ahora en mobile se ve así:
![image](https://github.com/user-attachments/assets/cc6b9133-5b7d-4273-9db0-2c6440e9a463)

En tablet se ve así, pero testeando con más cards encontré un bug que me mata:
![image](https://github.com/user-attachments/assets/6c871975-fc38-432d-ad41-238951ab814c)
![image](https://github.com/user-attachments/assets/e4a2fd62-8ec9-4ae8-9673-da7e7143e8e7)

Y en pc se ve así:
![image](https://github.com/user-attachments/assets/624468f9-27f1-49c7-8b17-f731cfc8cc5d)

> [!NOTE]
Qué conviene? Pasamos a grid para poder definir con más precisión cómo se van a ordernar las cards? A mí personalmente no me gusta que se quiebre la organización, tiene que ver con como trabaja justifyContent:center;
Seguramente noten que las cards tienen dimensiones irregulares cuando pasamos a una vista de grilla. Eso me pareció responsabilidad de la card, así que no lo toqué acá.