### PR TITLE
Aumento responsiveness de la vista de búsqueda

### DIFF
--- a/src/components/common/ClassRoomCard.tsx
+++ b/src/components/common/ClassRoomCard.tsx
@@ -127,11 +127,11 @@ export default function ClassRoomCard({
       <Card
         sx={{
           width: '100%',
-          maxWidth: 450,
+          flexGrow: 1,
           borderRadius: 3,
           boxShadow: 1,
           border: '1px solid #e0e0e0',
-          '@media (max-width: 600px)': { maxWidth: '90%' }
+          '@media (min-width: 1201px)': { width: '95%' }
         }}
       >
         <CardActionArea onClick={onClick}>

--- a/src/components/common/ClassRoomCard.tsx
+++ b/src/components/common/ClassRoomCard.tsx
@@ -142,7 +142,6 @@ export default function ClassRoomCard({
                     <Typography
                       variant="h5"
                       sx={{
-                        color: '#333',
                         fontWeight: 'bold',
                         whiteSpace: 'nowrap',
                         maxWidth: '100%',
@@ -153,12 +152,20 @@ export default function ClassRoomCard({
                       {course?.name}
                     </Typography>
                   </Tooltip>
-                  <Typography
-                    variant="h5"
-                    sx={{ color: '#333', fontWeight: 'bold' }}
-                  >
-                    {course?.events}
-                  </Typography>
+                  <Tooltip title={course?.events} arrow placement="bottom">
+                    <Typography
+                      variant="h5"
+                      sx={{
+                        fontWeight: 'bold',
+                        whiteSpace: 'nowrap',
+                        maxWidth: '90%',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {course?.events}
+                    </Typography>
+                  </Tooltip>
                 </Box>
                 <Divider sx={{ mb: 0.5 }} />
               </>

--- a/src/components/common/ClassRoomCard.tsx
+++ b/src/components/common/ClassRoomCard.tsx
@@ -39,12 +39,7 @@ export default function ClassRoomCard({
   //const formattedMode = mode.charAt(0).toUpperCase() + mode.slice(1).toLowerCase()
 
   /* //TODO: COMENTARIOS DE MEJORAS
-   * - Cambiar el formato de horario
-   *     Horario:
-   *        Lunes: 08:00 - 10:00
-   *        Martes: 18:00 - 22:00
    * - Agregar el botón de edición (SpeedDialEditActions)
-   * - Agregar al modal los distintos edificios y aulas (en el caso de que se curse en distintos edificios)
    * - Crear el modal para editar la materia
    */
 
@@ -97,7 +92,7 @@ export default function ClassRoomCard({
     if (course) {
       return course.professors
     } else if(schedule) {
-      return schedule?.professors.map((professor) => professor).join(', ')
+      return schedule?.professors.map((professor) => professor).join(' - ')
     } else {
       return event?.schedules[0]?.professors.map((professor) => professor).join(', ')
     }
@@ -279,12 +274,15 @@ export default function ClassRoomCard({
 
               {/* Horario */}
               <Clock size={24} color="#1976d2" />
-              <Typography
-                variant="body2"
-                sx={{ color: '#666', display: 'flex', textAlign: 'left' }}
-              >
-                Horario: {timeSchedule()}
-              </Typography>
+              <Box sx={{ maxWidth: '100%', overflow: 'hidden' }}>
+                    <Tooltip title={timeSchedule()} arrow>
+                      <Typography
+                        variant="body2"
+                        sx={{color: '#666',whiteSpace: 'nowrap',overflow: 'hidden',textOverflow: 'ellipsis',display: 'block',textAlign: 'left'}}>
+                         Horario: {timeSchedule()}
+                      </Typography>
+                    </Tooltip>
+                  </Box>
 
               {/* Carreras */}
               {programs() && (

--- a/src/components/common/EventTabs.tsx
+++ b/src/components/common/EventTabs.tsx
@@ -7,7 +7,13 @@ import { IEvent } from '@/data/domain/Event'
 import { Laptop } from '@phosphor-icons/react'
 import '../pages/search/search.css'
 
-function CustomTabPanel(props: { children?: React.ReactNode; value: number; index: number }) {
+interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+function CustomTabPanel(props: TabPanelProps) {
   const { children, value, index, ...other } = props
 
   return (
@@ -21,6 +27,13 @@ function CustomTabPanel(props: { children?: React.ReactNode; value: number; inde
       {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
     </div>
   )
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  }
 }
 
 export default function EventTabs({ events }: { events: IEvent[] }) {

--- a/src/components/common/EventTabs.tsx
+++ b/src/components/common/EventTabs.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react"
+import { Box, Tabs, Tab, Typography } from "@mui/material"
+import MapSelector from "@/components/common/map/MapSelector"
+import ClassRoomCard from "@/components/common/ClassRoomCard"
+
+function CustomTabPanel(props: { children?: React.ReactNode; value: number; index: number }) {
+  const { children, value, index, ...other } = props
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  )
+}
+
+export default function EventTabs({ events }: { events: IEventList[] }) {
+  const [tabStates, setTabStates] = useState<{ [eventId: string]: number }>({})
+
+  const handleTabChange = (eventId: string, newValue: number) => {
+    setTabStates((prev) => ({
+      ...prev,
+      [eventId]: newValue,
+    }))
+  }
+
+  return (
+    <>
+      {events.map((event) => {
+        const activeTab = tabStates[event.id] || 0 // Índice de la pestaña activa para este evento
+        return (
+          <Box key={event.id} sx={{ mb: 4 }}>
+            <Typography variant="h6" sx={{ fontWeight: "bold", mb: 2 }}>
+              {event.name}
+            </Typography>
+            <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+              <Tabs
+                value={activeTab}
+                onChange={(e, newValue) => handleTabChange(event.id, newValue)}
+                variant="scrollable"
+                scrollButtons="auto"
+              >
+                {event.schedules.map((schedule) => (
+                  <Tab
+                    key={schedule.id}
+                    label={schedule.weekDay || "Sin día"}
+                    sx={{ textTransform: "none", fontWeight: "bold" }}
+                  />
+                ))}
+              </Tabs>
+            </Box>
+            {event.schedules.map((schedule, index) => (
+              <CustomTabPanel key={schedule.id} value={activeTab} index={index}>
+                {!schedule.isVirtual ? (
+                  <>
+                    <Typography variant="h6" component="h2">
+                      {schedule.classroom?.name} - Piso {schedule.classroom?.floor} -{" "}
+                      {schedule.classroom?.building.name}
+                    </Typography>
+                    <MapSelector
+                      building={schedule.classroom?.building.name}
+                      level={schedule.classroom?.floor.toString()}
+                      classRoom={schedule.classroom?.code}
+                    />
+                  </>
+                ) : (
+                  <Box display="flex" flexDirection="column" alignItems="center">
+                    <Typography variant="h6" component="h2">
+                      Esta clase se dicta de forma virtual
+                    </Typography>
+                  </Box>
+                )}
+                <ClassRoomCard schedule={schedule} viewType="modal" />
+              </CustomTabPanel>
+            ))}
+          </Box>
+        )
+      })}
+    </>
+  )
+}

--- a/src/components/common/EventTabs.tsx
+++ b/src/components/common/EventTabs.tsx
@@ -34,10 +34,16 @@ export default function EventTabs({ events }: { events: IEvent[] }) {
   }
 
   const createLabel = (schedule : ISchedule) => {
+    if (!schedule.weekDay && !schedule.date) {
+      return "Sin fecha"
+    }
     if (schedule.weekDay) {
       return schedule.weekDay
     }
+    return buildDateString(schedule)
+  }
 
+  const buildDateString = (schedule: ISchedule) => {
     const date = new Date(schedule.date!!)
   
     const day = date.getDate().toString().padStart(2, '0')

--- a/src/components/common/EventTabs.tsx
+++ b/src/components/common/EventTabs.tsx
@@ -33,6 +33,19 @@ export default function EventTabs({ events }: { events: IEvent[] }) {
     }))
   }
 
+  const createLabel = (schedule : ISchedule) => {
+    if (schedule.weekDay) {
+      return schedule.weekDay
+    }
+
+    const date = new Date(schedule.date!!)
+  
+    const day = date.getDate().toString().padStart(2, '0')
+    const month = (date.getMonth() + 1).toString().padStart(2, '0')
+    
+    return `${day}/${month}`
+  }
+
   return (
     <>
       {events.map((event) => {
@@ -57,7 +70,7 @@ export default function EventTabs({ events }: { events: IEvent[] }) {
                 {event.schedules.map((schedule: ISchedule) => (
                   <Tab
                     key={schedule.id}
-                    label={schedule.weekDay || "Sin día"}
+                    label={ createLabel(schedule) }
                     sx={{
                       textTransform: "none",
                       fontWeight: "bold"

--- a/src/components/common/EventTabs.tsx
+++ b/src/components/common/EventTabs.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react"
-import { Box, Tabs, Tab, Typography } from "@mui/material"
-import MapSelector from "@/components/common/map/MapSelector"
-import ClassRoomCard from "@/components/common/ClassRoomCard"
+import { Box, Tabs, Tab, Typography } from '@mui/material'
+import { MapSelector } from '@/components/common/map/MapSelector'
+import ClassRoomCard from '@/components/common/ClassRoomCard'
+import { ISchedule } from '@/data/domain/Schedule'
+import { IEvent } from '@/data/domain/Event'
+import { Laptop } from '@phosphor-icons/react'
+import '../pages/search/search.css'
 
 function CustomTabPanel(props: { children?: React.ReactNode; value: number; index: number }) {
   const { children, value, index, ...other } = props
@@ -19,7 +23,7 @@ function CustomTabPanel(props: { children?: React.ReactNode; value: number; inde
   )
 }
 
-export default function EventTabs({ events }: { events: IEventList[] }) {
+export default function EventTabs({ events }: { events: IEvent[] }) {
   const [tabStates, setTabStates] = useState<{ [eventId: string]: number }>({})
 
   const handleTabChange = (eventId: string, newValue: number) => {
@@ -35,47 +39,96 @@ export default function EventTabs({ events }: { events: IEventList[] }) {
         const activeTab = tabStates[event.id] || 0 // Índice de la pestaña activa para este evento
         return (
           <Box key={event.id} sx={{ mb: 4 }}>
-            <Typography variant="h6" sx={{ fontWeight: "bold", mb: 2 }}>
+            <Typography
+              variant="h6"
+              sx={{
+                  textAlign: "center",
+                  fontWeight: "bold"
+                }}
+            >
               {event.name}
             </Typography>
             <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
               <Tabs
                 value={activeTab}
                 onChange={(e, newValue) => handleTabChange(event.id, newValue)}
-                variant="scrollable"
-                scrollButtons="auto"
+                variant="fullWidth"
               >
-                {event.schedules.map((schedule) => (
+                {event.schedules.map((schedule: ISchedule) => (
                   <Tab
                     key={schedule.id}
                     label={schedule.weekDay || "Sin día"}
-                    sx={{ textTransform: "none", fontWeight: "bold" }}
+                    sx={{
+                      textTransform: "none",
+                      fontWeight: "bold"
+                    }}
                   />
                 ))}
               </Tabs>
             </Box>
-            {event.schedules.map((schedule, index) => (
-              <CustomTabPanel key={schedule.id} value={activeTab} index={index}>
-                {!schedule.isVirtual ? (
-                  <>
-                    <Typography variant="h6" component="h2">
-                      {schedule.classroom?.name} - Piso {schedule.classroom?.floor} -{" "}
-                      {schedule.classroom?.building.name}
-                    </Typography>
-                    <MapSelector
-                      building={schedule.classroom?.building.name}
-                      level={schedule.classroom?.floor.toString()}
-                      classRoom={schedule.classroom?.code}
+            {event.schedules.map((schedule: ISchedule, index) => (
+              <CustomTabPanel
+                key={schedule.id}
+                value={activeTab}
+                index={index}
+              >
+                <section className="schedules-list-container">
+                  <div
+                    className={`schedules-list ${event.schedules.length == 1 ? 'single' : ''}`}
+                  >
+                    {!schedule.isVirtual ? (
+                      <article className="schedules-list-item">
+                        <Typography
+                          id="modal-modal-title"
+                          variant="h6"
+                          component="h2"
+                          sx={{
+                            textAlign: 'center',
+                            wordBreak: 'break-word',
+                            whiteSpace: 'normal'
+                          }}
+                        >
+                          {schedule.classroom?.name} / Piso{' '}
+                          {schedule.classroom?.floor} /{' '}
+                          {schedule.classroom?.building.name}
+                        </Typography>
+                        <MapSelector
+                          building={schedule.classroom?.building.name}
+                          level={schedule.classroom?.floor.toString()}
+                          classRoom={schedule.classroom?.code}
+                        />
+                      </article>
+                    ) : (
+                      <Box
+                        display="flex"
+                        flexDirection="column"
+                        alignItems="center"
+                      >
+                        <Typography
+                          id="modal-modal-title"
+                          variant="h6"
+                          component="h2"
+                          sx={{
+                            textAlign: 'center',
+                            wordBreak: 'break-word',
+                            whiteSpace: 'normal'
+                          }}
+                        >
+                          Esta clase se dicta de forma virtual
+                        </Typography>
+                        <Laptop
+                          size={150}
+                          color="#2e4b7d"
+                          weight="duotone"
+                        />
+                      </Box>
+                    )}
+                    <ClassRoomCard
+                      schedule={schedule}
+                      viewType="modal"
                     />
-                  </>
-                ) : (
-                  <Box display="flex" flexDirection="column" alignItems="center">
-                    <Typography variant="h6" component="h2">
-                      Esta clase se dicta de forma virtual
-                    </Typography>
-                  </Box>
-                )}
-                <ClassRoomCard schedule={schedule} viewType="modal" />
+                  </div>
+                </section>
               </CustomTabPanel>
             ))}
           </Box>

--- a/src/components/common/InfoModal.tsx
+++ b/src/components/common/InfoModal.tsx
@@ -30,28 +30,23 @@ export default function InfoModal({
       onClose={handleClose}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
-      sx={{
-        maxHeight: '80vh',
-        minHeight: '85vh',
-        width: '90vw',
-        overflowY: 'hidden',
-        borderRadius: '24px',
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        bgcolor: 'background.paper',
-        boxShadow: 3,
-        transform: 'translate(-50%, -55%)'
-      }}
+      keepMounted
     >
       <Fade in={open}>
         <Box
           sx={{
+            maxHeight: '80vh',
+            minHeight: '85vh',
+            width: '90vw',
+            overflowY: 'hidden',
+            borderRadius: '24px',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
             bgcolor: 'background.paper',
-            width: '100%',
-            height: '100%',
-            p: 2,
-            position: 'relative'
+            boxShadow: 3,
+            transform: 'translate(-50%, -55%)',
+            p: 2
           }}
         >
           <Box

--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -90,7 +90,6 @@ export default function Nav() {
           onClick={() => navigate('/perfil')}
           className={`${isActive(['/perfil', '/ingresar']) ? 'active' : ''} logo-container nav-icon`}
           aria-label={isAuthenticated ? 'Ir al perfil' : 'Ingresar'}
-          disableRipple
         >
           {isAuthenticated && (
             <>

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -1,6 +1,6 @@
 import ClassRoomCard from '@/components/common/ClassRoomCard'
 import SearchBar from '@/components/common/SearchBar'
-import { Box, Divider, Grid2, Tab, Tabs, Typography } from '@mui/material'
+import { Box, Divider, Grid2, Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
 import InfoModal from '@/components/common/InfoModal'
 import './search.css'
@@ -11,6 +11,7 @@ import { courseService } from '@/data/services/CourseService'
 import { useNotification } from '@/context/NotificationContext'
 import { useLoader } from '@/context/LoaderContext'
 import { MapSelector } from '@/components/common/map/MapSelector'
+import EventTabs from '@/components/common/EventTabs'
 
 
 interface TabPanelProps {
@@ -205,7 +206,7 @@ export function Search() {
           subtitle="Cursadas y eventos"
         >
           <section className="class-info-container">
-            <Typography variant="h6" sx={{ mb: 2 }}>
+            <Typography variant="h6" fontWeight="medium" px="1rem">
               {selectedCourse?.programs?.map((program) => program).join(', ')}
             </Typography>
             <EventTabs events={selectedCourse.events} />

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -1,6 +1,6 @@
 import ClassRoomCard from '@/components/common/ClassRoomCard'
 import SearchBar from '@/components/common/SearchBar'
-import { Box, Divider, Grid2, Typography } from '@mui/material'
+import { Box, Divider, Grid2, Tab, Tabs, Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
 import InfoModal from '@/components/common/InfoModal'
 import './search.css'
@@ -12,10 +12,47 @@ import { useNotification } from '@/context/NotificationContext'
 import { useLoader } from '@/context/LoaderContext'
 import { MapSelector } from '@/components/common/map/MapSelector'
 
+
+interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  )
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
 export function Search() {
   const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null)
   const [open, setOpen] = useState(false)
   const [courses, setCourses] = useState<ICourseList[]>([])
+
+  // Estado para manejar el valor de la pestaña activa
+  const [value, setValue] = useState(0)
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue)
+  }
 
   const { setNotificationState } = useNotification()
   const { setLoader } = useLoader()
@@ -171,85 +208,7 @@ export function Search() {
             <Typography variant="h6" sx={{ mb: 2 }}>
               {selectedCourse?.programs?.map((program) => program).join(', ')}
             </Typography>
-            {selectedCourse.events.map((event) => (
-              <Box
-                key={event.id}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  flexDirection: 'column',
-                  width: '100%'
-                }}
-              >
-                <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-                  {event.name}
-                </Typography>
-                <section className="schedules-list-container">
-                  <div
-                    className={`schedules-list ${event.schedules.length == 1 ? 'single' : ''}`}
-                  >
-                    {event.schedules.map((schedule) => (
-                      <article
-                        key={schedule.id}
-                        className="schedules-list-item"
-                      >
-                        {!schedule.isVirtual ? (
-                          <>
-                            {/* Título del modal con información del edificio y nivel */}
-                            <Typography
-                              id="modal-modal-title"
-                              variant="h6"
-                              component="h2"
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center'
-                              }}
-                            >
-                              {schedule.classroom?.name} - Piso{' '}
-                              {schedule.classroom?.floor} -{' '}
-                              {schedule.classroom?.building.name}
-                            </Typography>
-                            {/* Mapa interactivo del subsuelo */}
-                            <MapSelector
-                              building={schedule.classroom?.building.name}
-                              level={schedule.classroom?.floor.toString()}
-                              classRoom={schedule.classroom?.code}
-                            />
-                          </>
-                        ) : (
-                          <Box
-                            display="flex"
-                            flexDirection="column"
-                            alignItems="center"
-                          >
-                            <Typography
-                              id="modal-modal-title"
-                              variant="h6"
-                              component="h2"
-                              sx={{
-                                textAlign: 'center',
-                                wordBreak: 'break-word',
-                                whiteSpace: 'normal'
-                              }}
-                            >
-                              Esta clase se dicta de forma virtual
-                            </Typography>
-                            <Laptop
-                              size={150}
-                              color="#2e4b7d"
-                              weight="duotone"
-                            />
-                          </Box>
-                        )}
-                        <ClassRoomCard schedule={schedule} viewType="modal" />
-                      </article>
-                    ))}
-                  </div>
-                </section>
-              </Box>
-            ))}
+            <EventTabs events={selectedCourse.events} />
           </section>
         </InfoModal>
       )}

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -10,38 +10,7 @@ import { ICourse, ICourseList } from '@/data/domain/Course'
 import { courseService } from '@/data/services/CourseService'
 import { useNotification } from '@/context/NotificationContext'
 import { useLoader } from '@/context/LoaderContext'
-import { MapSelector } from '@/components/common/map/MapSelector'
 import EventTabs from '@/components/common/EventTabs'
-
-
-interface TabPanelProps {
-  children?: React.ReactNode
-  index: number
-  value: number
-}
-
-function CustomTabPanel(props: TabPanelProps) {
-  const { children, value, index, ...other } = props;
-
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
-      {...other}
-    >
-      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
-    </div>
-  )
-}
-
-function a11yProps(index: number) {
-  return {
-    id: `simple-tab-${index}`,
-    'aria-controls': `simple-tabpanel-${index}`,
-  };
-}
 
 export function Search() {
   const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null)

--- a/src/components/pages/search/search.css
+++ b/src/components/pages/search/search.css
@@ -5,7 +5,7 @@
   gap: 1rem;
   height: 100%;
   overflow-y: scroll;
-  padding: 1rem 0;
+  padding-top: 1rem;
 }
 .schedules-list-container {
   display: flex;
@@ -16,23 +16,16 @@
 
 .schedules-list {
   display: flex;
+  flex-direction: column;
   gap: 1rem;
-  width: fit-content;
-  padding: 1rem ;
-}
-.schedules-list.single{
-  width: 100%;
 }
 
 .schedules-list-item {
   display: flex;
-  width: 65vw;
   flex-direction: column;
-  gap: 1rem;
   height: 100%;
   justify-content: space-between;
   min-height: 450px;
-  padding: 1rem 0.1rem;
   border-radius: 10px;
   /* background-color: var(--primary-color-light); */
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
@@ -44,3 +37,16 @@
 }
 
 /* Si schedules-list-item es only child, necesito que  */
+
+@Media (min-width:601px) {
+  .schedules-list-item {
+    gap: 1rem;
+    width: 75vw;
+  }
+}
+
+@Media (min-width:1201px) {
+  .schedules-list-item {
+    width: 60vw;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,7 +37,9 @@ let unsamTheme = createTheme({
   components: {
     MuiIconButton: {
       defaultProps: {
-        color: 'secondary'
+        color: 'secondary',
+        disableRipple: true,
+        disableFocusRipple: true
       }
     }
   }


### PR DESCRIPTION
Buenas, adapté un snippet de Tabs publicado por Material UI para poder darle todo el modal a cada schedule y dividir la información en días.
Escucho cualquier comentario o sugerencia que se pueda agregar sobre lo ya hecho.
Puedo seguir con el mapa en esta rama o si prefieren abro otra.

## Mobile
![image](https://github.com/user-attachments/assets/c23fcd9b-cd64-42dd-b302-491586c76635)
![image](https://github.com/user-attachments/assets/83e5c703-ce47-4652-bb2a-bb98ffb541a3)

## Tablet
### Sí, las pestañas representan distintos schedules
![image](https://github.com/user-attachments/assets/6f776254-5363-4d78-9356-0adc0575aa85)
Se "controla" que llegue un schedule sin día con esa pestaña, creo que en realidad no debería poder llegar un schedule sin día, no?
![image](https://github.com/user-attachments/assets/cddbe962-934c-48ba-9ad4-0729aca5c3d4)

## Web
![image](https://github.com/user-attachments/assets/c171c03e-dc84-42a5-8bb7-a39867bc0017)
![image](https://github.com/user-attachments/assets/030c41ab-ec39-49ea-b082-54ed0d69c5e2)
